### PR TITLE
Read full response from the socket

### DIFF
--- a/ipc.go
+++ b/ipc.go
@@ -72,13 +72,23 @@ func (c *ipc) request(a Args) ([]byte, error) {
 		return nil, err
 	}
 
-	var buf = make([]byte, BufSize)
-	n, err := conn.Read(buf)
-	if err != nil {
-		return nil, err
+	var response []byte
+	buf := make([]byte, BufSize)
+
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		response = append(response, buf[:n]...)
+
+		if n < BufSize {
+			break
+		}
 	}
 
-	return buf[:n], nil
+	return response, nil
 }
 
 // wrapreq


### PR DESCRIPTION
Your `request()` method was returning only first `BufSize` bytes (8192) from the socket response.  So if, for example, you have a lot of windows open and try to run `ipc.Clients()`  - you'll get `unexpected end of JSON input` error because whole json couldn't fit into `BufSize`.

Go tests results:
```shell

❯ go test -coverpkg=./... ./... -parallel=2
--- FAIL: Test_ipc_Clients (0.00s)
    ipc_test.go:14: unexpected end of JSON input
    ipc_test.go:18: got is empty
FAIL
coverage: 67.1% of statements in ./...
FAIL    github.com/labi-le/hyprland-ipc-client  0.172s
FAIL
make: *** [Makefile:4: tests] Error 1
```

This PR should fix the issue by appending all buffers into final `response` byte slice.

