### PR TITLE
Fix batch command support

### DIFF
--- a/argv.go
+++ b/argv.go
@@ -108,6 +108,8 @@ func (q *PriorityQueue[T]) Back(value T) {
 
 type ByteQueue struct {
 	*PriorityQueue[[]byte]
+	batch   bool
+	command []byte
 }
 
 func NewByteQueue() *ByteQueue {
@@ -117,9 +119,17 @@ func NewByteQueue() *ByteQueue {
 func (q *ByteQueue) Glue() []byte {
 	var glued []byte
 
+	if q.batch {
+		glued = append(glued, []byte("[[BATCH]]")...)
+	}
+
 	for !q.IsEmpty() {
+		if q.command != nil {
+			glued = append(glued, q.command...)
+			glued = append(glued, ' ')
+		}
 		glued = append(glued, q.Pop()...)
-		glued = append(glued, ' ')
+		glued = append(glued, ';')
 	}
 
 	if len(glued) > 0 {

--- a/argv_test.go
+++ b/argv_test.go
@@ -7,13 +7,15 @@ import (
 
 func Test_priorityQueue_Add(t *testing.T) {
 	queue := NewByteQueue()
+	queue.batch = true
+	queue.command = []byte("command")
 	queue.Add([]byte("name"))
 	queue.Add([]byte("ivan"))
 	queue.Back([]byte("my"))
 	queue.Back([]byte("hello"))
 
 	glued := queue.Glue()
-	if !bytes.Equal(glued, []byte("hello my name ivan")) {
+	if !bytes.Equal(glued, []byte("[[BATCH]]command hello;command my;command name;command ivan")) {
 		t.Errorf("got %s", glued)
 	}
 }

--- a/ipc.go
+++ b/ipc.go
@@ -67,7 +67,7 @@ func NewClient(readSock, writeSock string) *IPCClient {
 }
 
 func (c *IPCClient) request(q *ByteQueue) ([]byte, error) {
-	if q.Len() == 0 {
+	if q.command == nil && q.Len() == 0 {
 		return nil, errors.New("wtfuq man you need to pass some args")
 	}
 
@@ -79,7 +79,7 @@ func (c *IPCClient) request(q *ByteQueue) ([]byte, error) {
 	}
 
 	if q.Len() > 1 {
-		q.Back([]byte("[[BATCH]]"))
+		q.batch = true
 	}
 
 	glued := q.Glue()
@@ -175,7 +175,7 @@ func (c *IPCClient) Receive() ([]ReceivedData, error) {
 }
 
 func (c *IPCClient) Dispatch(a *ByteQueue) ([]byte, error) {
-	a.Back([]byte("dispatch"))
+	a.command = []byte("dispatch")
 
 	return c.request(a)
 }
@@ -216,7 +216,7 @@ func (c *IPCClient) Devices() (Devices, error) {
 }
 
 func (c *IPCClient) Keyword(args *ByteQueue) error {
-	args.Back([]byte("keyword"))
+	args.command = []byte("keyword")
 
 	response, err := c.request(args)
 	if err != nil {
@@ -255,7 +255,7 @@ func (c *IPCClient) SetCursor(theme, size string) error {
 	q := NewByteQueue()
 	q.Add(UnsafeBytes(theme))
 	q.Add(UnsafeBytes(size))
-	q.Back([]byte("setcursor"))
+	q.command = []byte("setcursor")
 
 	_, err := c.request(q)
 	return err
@@ -264,7 +264,7 @@ func (c *IPCClient) SetCursor(theme, size string) error {
 func (c *IPCClient) GetOption(name string) (string, error) {
 	q := NewByteQueue()
 	q.Add(UnsafeBytes(name))
-	q.Back([]byte("getoption"))
+	q.command = []byte("getoption")
 
 	buf, err := c.request(q)
 	if err != nil {
@@ -276,7 +276,7 @@ func (c *IPCClient) GetOption(name string) (string, error) {
 
 func (c *IPCClient) Splash() (string, error) {
 	q := NewByteQueue()
-	q.Back([]byte("splash"))
+	q.command = []byte("splash")
 
 	buf, err := c.request(q)
 	if err != nil {

--- a/ipc_test.go
+++ b/ipc_test.go
@@ -182,7 +182,9 @@ func Test_ipc_CursorPos(t *testing.T) {
 
 func TestIpc_Dispatch(t *testing.T) {
 	q := NewByteQueue()
-	q.Add([]byte("exec"))
+	q.Add([]byte("exec kitty"))
+	q.Add([]byte("exec kitty"))
+	q.Add([]byte("exec kitty"))
 	_, err := ipctest.Dispatch(q)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Fix https://github.com/labi-le/hyprland-ipc-client/issues/7. Doesn't fix the max command by batch issue though, this will need further changes.

This PR extends `ByteQueue` to add `batch` and `command` fields. `batch` now serves to indicate if the command batch will be a batch, instead of abusing `ByteQueue.Back()`. `command` is a special field that will be prepend to all commands executed in the `ByteQueue`.

See `Test_priorityQueue_Add` for more details.