### PR TITLE
add support for screencast events

### DIFF
--- a/event.go
+++ b/event.go
@@ -109,8 +109,13 @@ func processEvent(ev EventHandler, msg ReceivedData, events []EventType) {
 				// e.g. idk
 				ev.SubMap(SubMap(raw[0]))
 				break
+			case EventScreencast:
+				ev.Screencast(Screencast{
+					Sharing: raw[0] == "1",
+					Owner:   raw[1],
+				})
+				break
 			}
-
 		}
 	}
 }

--- a/event_dummy.go
+++ b/event_dummy.go
@@ -18,3 +18,4 @@ func (e *DummyEvHandler) MoveWindow(MoveWindow)          {}
 func (e *DummyEvHandler) OpenLayer(OpenLayer)            {}
 func (e *DummyEvHandler) CloseLayer(CloseLayer)          {}
 func (e *DummyEvHandler) SubMap(SubMap)                  {}
+func (e *DummyEvHandler) Screencast(Screencast)          {}

--- a/event_test.go
+++ b/event_test.go
@@ -103,6 +103,11 @@ func (f FakeClient) Receive() ([]ReceivedData, error) {
 			Data: "1",
 			// idk
 		},
+
+		{
+			Type: EventScreencast,
+			Data: "1,0",
+		},
 	}, nil
 }
 

--- a/event_type.go
+++ b/event_type.go
@@ -34,6 +34,7 @@ type EventHandler interface {
 	CloseLayer(c CloseLayer)
 	// SubMap emitted when a keybind submap changes. Empty means default.
 	SubMap(s SubMap)
+	Screencast(s Screencast)
 }
 
 type EventType string
@@ -55,6 +56,7 @@ const (
 	EventOpenLayer        EventType = "openlayer"
 	EventCloseLayer       EventType = "closelayer"
 	EventSubMap           EventType = "submap"
+	EventScreencast       EventType = "screencast"
 )
 
 func GetAllEvents() []EventType {
@@ -75,6 +77,7 @@ func GetAllEvents() []EventType {
 		EventOpenLayer,
 		EventCloseLayer,
 		EventSubMap,
+		EventScreencast,
 	}
 }
 
@@ -121,3 +124,11 @@ type ActiveWindow struct {
 }
 
 type ActiveWorkspace WorkspaceName
+
+type Screencast struct {
+	// True if a screen or window is being shared.
+	Sharing bool
+
+	// "0" if monitor is shared, "1" if window is shared.
+	Owner string
+}


### PR DESCRIPTION
I changed the `state` field (as documented in hyprland wiki) to `sharing` and made it a bool, since I think that's clearer.  I left the `owner` field as a string, since I suspect we could eventually see other values for things like regions, perhaps.  I'm happy to stick closer to how hyprland names things though, if you'd prefer.